### PR TITLE
Spotify-aTisket: Fixed button position during playback

### DIFF
--- a/spotify_atisket_link.user.js
+++ b/spotify_atisket_link.user.js
@@ -37,7 +37,7 @@ function addAtisketLink(path) {
         </button>`
     ).hide();
 
-    $('button[title="Save to Your Library"]').first().after(atisketButton);
+    $('button[title="More"]').first().before(atisketButton);
     atisketButton.show();
 }
 


### PR DESCRIPTION
Currently, playback in Spotify will reposition the button. With playback active, a div—"now-playing-bar"—is positioned first on the page. The aTisket button appears on the now-playing bar, as there is a "Save to Your Library" button in the div, which is not the intended location.

Example: (aTisket button in now playing bar)
![Example with aTisket button in now playing bar](https://i.imgur.com/Rty56lx.png)

My solution was to position the button relative to the "more" button, (the three dots) which consistently places the aTisket button by the album art/save button/play button and not in the now-playing bar.

Example: (nearly the same image as in your [forum post](https://community.metabrainz.org/t/a-multi-source-seeder-for-digital-releases/444000/163))
![Example in corrected position](https://i.imgur.com/HvKyVdN.png)

_Side note: thank you for writing this script! 
I'm going to attempt to port it to [Spicetify](https://github.com/khanhas/spicetify-cli) as an extension to place a button in the Spotify desktop app._