### PR TITLE
Use safest match and explicit run-at

### DIFF
--- a/deezer_atisket_link.user.js
+++ b/deezer_atisket_link.user.js
@@ -1,15 +1,16 @@
 // ==UserScript==
 // @name        Add a-tisket import link to Deezer
-// @version     2021.1.13.1
+// @version     2021.1.30.1
 // @description Adds a link to Deezer to import a release into MusicBrainz via a-tisket
 // @author      atj
 // @license     MIT; https://opensource.org/licenses/MIT
 // @namespace   https://github.com/atj/userscripts
 // @downloadURL https://raw.github.com/atj/userscripts/master/deezer_atisket_link.user.js
 // @updateURL	https://raw.github.com/atj/userscripts/master/deezer_atisket_link.user.js
-// @include     http*://www.deezer.com/*
+// @match       *://www.deezer.com/*
 // @require     https://code.jquery.com/jquery-3.5.1.slim.min.js
 // @grant       none
+// @run-at      document-idle
 // ==/UserScript==
 
 // change this to link to a different a-tisket instance

--- a/mb_semi-automate_adding_remix_credits.user.js
+++ b/mb_semi-automate_adding_remix_credits.user.js
@@ -1,14 +1,15 @@
 // ==UserScript==
 // @name        MusicBrainz: Semi-automate adding "remixer" and "remix of" credits
-// @version     2021.1.21.1
+// @version     2021.1.30.1
 // @description Adds links to the relationship editor that semi-automate adding "remixer" and "remix-of" credits
 // @author      atj
 // @license     MIT; https://opensource.org/licenses/MIT
 // @namespace   https://github.com/atj/userscripts
 // @downloadURL https://raw.github.com/atj/userscripts/master/mb_add_remix_credit_links.user.js
 // @updateURL   https://raw.github.com/atj/userscripts/master/mb_add_remix_credit_links.user.js
-// @match       http*://*.musicbrainz.org/release/*/edit-relationships
+// @match       *://*.musicbrainz.org/release/*/edit-relationships
 // @grant       none
+// @run-at      document-idle
 // ==/UserScript==
 
 /* Examples of track titles that this regex should match:

--- a/mb_spotify_isrc_link.user.js
+++ b/mb_spotify_isrc_link.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Add Spotify ISRC link to release pages
-// @version     2020.12.26.1
+// @version     2021.1.30.1
 // @description Adds an "import ISRCs" link to release pages with a Spotify URL
 // @author      atj
 // @license     MIT; https://opensource.org/licenses/MIT
@@ -8,8 +8,9 @@
 // @downloadURL https://raw.github.com/atj/userscripts/master/mb_spotify_isrc_link.user.js
 // @updateURL	https://raw.github.com/atj/userscripts/master/mb_spotify_isrc_link.user.js
 // @require     https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js
-// @match       http*://*.musicbrainz.org/release/*
+// @match       *://*.musicbrainz.org/release/*
 // @grant       none
+// @run-at      document-idle
 // ==/UserScript==
 
 // prevent JQuery conflicts, see http://wiki.greasespot.net/@grant

--- a/spotify_atisket_link.user.js
+++ b/spotify_atisket_link.user.js
@@ -1,15 +1,16 @@
 // ==UserScript==
 // @name        Add a-tisket import link to Spotify
-// @version     2021.1.13.1
+// @version     2021.1.30.1
 // @description Adds a link to Spotify to import a release into MusicBrainz via a-tisket
 // @author      atj
 // @license     MIT; https://opensource.org/licenses/MIT
 // @namespace   https://github.com/atj/userscripts
 // @downloadURL https://raw.github.com/atj/userscripts/master/spotify_atisket_link.user.js
 // @updateURL   https://raw.github.com/atj/userscripts/master/spotify_atisket_link.user.js
-// @include     http*://open.spotify.com/*
+// @match       *://open.spotify.com/*
 // @require     https://code.jquery.com/jquery-3.5.1.slim.min.js
 // @grant       none
+// @run-at      document-idle
 // ==/UserScript==
 
 // change this to link to a different a-tisket instance


### PR DESCRIPTION
Match
--------

**Match** is safest than include with protocol/scheme set as * stands for
`http` and `https`.

**It should fix #6.**

See https://developer.chrome.com/extensions/match_patterns

Run-at
---------

**Run-at** has not the same default value in Tampermonkey (`document-idle`)
than in Violentmonkey and Greasemonkey (`document-end`).
I chose `document-idle` because I thought you were using Tampermonkey.
But you can replace by other value, if your tests tells you so. :)

**Maybe it will fix **chaban** [spotted issue](https://community.metabrainz.org/t/userscript-semi-automate-adding-remixer-and-remix-of-credits/516316/5?u=jesus2099).**

See:

- https://wiki.greasespot.net/Metadata_Block#.40run-at
- https://violentmonkey.github.io/api/metadata-block/#run-at
- https://www.tampermonkey.net/documentation.php#_run_at

Very useful doc
--------------------

- https://wiki.greasespot.net/Metadata_Block
- https://violentmonkey.github.io/api/metadata-block/
- https://www.tampermonkey.net/documentation.php#metadata