### PR TITLE
spotify_atisket_link: fix selector and URL

### DIFF
--- a/spotify_atisket_link.user.js
+++ b/spotify_atisket_link.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Add a-tisket import link to Spotify
-// @version     2021.10.04.1
+// @version     2023.7.08
 // @description Adds a link to Spotify to import a release into MusicBrainz via a-tisket
 // @author      atj
 // @license     MIT; https://opensource.org/licenses/MIT
@@ -32,16 +32,19 @@ function addAtisketLink(path) {
     // remove any old instances of the button in the DOM
     $('#atisket').remove();
 
-    let atisketLink = `${ATISKET}/?preferred_countries=${COUNTRIES}&spf_id=${spotifyReleaseId}`;
+    let atisketLink = `${ATISKET}/?preferred_countries=${COUNTRIES}&spf_id=${spotifyReleaseId}&preferred_vendor=spf`;
+    let moreButton = $('button[aria-label*="More"]').first();
     let atisketButton = $(
-        `<button type="button" id="atisket" class="B77TpDT6WaoYUqQxvy4Z" style="padding:6px;border:1px solid;border-radius:5px;">
+        `<button type="button" id="atisket" class="${moreButton.attr(
+            'class'
+        )}" style="padding:6px;border:1px solid;border-radius:5px;">
             <a href="${atisketLink}" target="_blank">
                 → a-tisket
             </a>
         </button>`
     ).hide();
 
-    $('button[aria-label="More"]').first().before(atisketButton);
+    moreButton.before(atisketButton);
     atisketButton.show();
 }
 


### PR DESCRIPTION
Seems like the button title is now "More options for \<artist\>" instead of just "More".
Class name has also changed again, so to future-proof it I'm proposing to reuse the "More" button's class instead of hardcoding it.
Also adding `preferred_vendor=spf` because of consistency with pasting in the link on the site itself. Also, without it, for some reason it doesn't always find a Deezer release 🤷