### PR TITLE
Update add remix credit links to work with current MB interface

### DIFF
--- a/mb_add_remix_credit_links.user.js
+++ b/mb_add_remix_credit_links.user.js
@@ -171,6 +171,9 @@ function addRemixCreditClickHandler(event) {
 }
 
 // wait 500ms for the page to fully initialise
-window.setTimeout(function () {
-    addRemixCreditLinks();
+const intervalId = window.setInterval(function () {
+    if (!document.querySelector('.loading-message')) {
+        window.clearInterval(intervalId);
+        addRemixCreditLinks();
+    }
 }, 500);

--- a/mb_add_remix_credit_links.user.js
+++ b/mb_add_remix_credit_links.user.js
@@ -28,7 +28,7 @@
  * The Rainbow Song (Crackazat rework)
  */
 const TitleRemixRegexp =
-    /^\s*(.+)\s+\(\s*(.+)\s+(?:(?:re)?mix|re-?(?:[dr]ub|edit|work)|edit).*\)/i;
+    /^\s*(.+)\s+\(\s*(.+)\s+(?:(?:re-?)?(?:[dr]ub|edit|mix)|re-?work).*\)/i;
 
 // This code is based on:
 // https://stackoverflow.com/questions/42795059/programmatically-fill-reactjs-form

--- a/mb_add_remix_credit_links.user.js
+++ b/mb_add_remix_credit_links.user.js
@@ -30,8 +30,6 @@
 const TitleRemixRegexp =
     /^\s*(.+)\s+\(\s*(.+)\s+(?:(?:re)?mix|re-?(?:[dr]ub|edit|work)|edit).*\)/i;
 
-const AddIconUri = 'https://staticbrainz.org/MB/add-e585eab.png';
-
 // This code is based on:
 // https://stackoverflow.com/questions/42795059/programmatically-fill-reactjs-form
 function setElementValue(element, value, event = 'input') {
@@ -54,15 +52,6 @@ function setElementValue(element, value, event = 'input') {
     }
 
     element.dispatchEvent(new Event(event, { bubbles: true }));
-}
-
-function addStyleElement() {
-    const style = document.createElement('style');
-    style.type = 'text/css';
-    document.head.appendChild(style);
-    style.appendChild(
-        document.createTextNode('.add-rc { display: inline-block; }')
-    );
 }
 
 function addRemixCreditLinks() {
@@ -88,25 +77,24 @@ function addRemixCreditLinks() {
             linkTypes[link.innerText] = 1;
         }
 
-        let span = document.createElement('span');
+        let button = document.createElement('button');
         if (linkTypes['remixer:']) {
-            span.className = 'add-rc btn disabled';
+            button.className = 'add-item with-label btn disabled';
         } else {
-            span.className = 'add-rc btn';
-            span.onclick = addRemixCreditClickHandler;
-            span.setAttribute('data-remixer', matches[2]);
+            button.className = 'add-item with-label';
+            button.onclick = addRemixCreditClickHandler;
+            button.setAttribute('data-remixer', matches[2]);
         }
 
-        span.innerHTML = `
-            <img class="bottom" src="${AddIconUri}">
+        button.innerHTML = `
             Add "remixer" credit
         `;
-        recording.appendChild(span);
+        recording.appendChild(button);
         recording.appendChild(document.createTextNode('\n'));
 
-        span = document.createElement('span');
+        button = document.createElement('button');
         if (linkTypes['remix of:']) {
-            span.className = 'add-rc btn disabled';
+            button.className = 'add-item with-label btn disabled';
         } else {
             const trackArtistElement = recording
                     .getElementsByTagName('span')[1];
@@ -120,16 +108,15 @@ function addRemixCreditLinks() {
             // recording search will be pre-filled with title and artists to improve the results
             const recordingQuery = `${matches[1]} ${trackArtists.join(' ')}`;
 
-            span.className = 'add-rc btn';
-            span.onclick = addRemixCreditClickHandler;
-            span.setAttribute('data-remix-of', recordingQuery);
+            button.className = 'add-item with-label';
+            button.onclick = addRemixCreditClickHandler;
+            button.setAttribute('data-remix-of', recordingQuery);
         }
 
-        span.innerHTML = `
-            <img class="bottom" src="${AddIconUri}">
+        button.innerHTML = `
             Add "remix of" credit
         `;
-        recording.appendChild(span);
+        recording.appendChild(button);
     }
 }
 
@@ -185,6 +172,5 @@ function addRemixCreditClickHandler(event) {
 
 // wait 500ms for the page to fully initialise
 window.setTimeout(function () {
-    addStyleElement();
     addRemixCreditLinks();
 }, 500);

--- a/mb_add_remix_credit_links.user.js
+++ b/mb_add_remix_credit_links.user.js
@@ -31,10 +31,6 @@ const TitleRemixRegexp =
     /^\s*(.+)\s+\(\s*(.+)\s+(?:(?:re)?mix|re-?(?:[dr]ub|edit|work)|edit).*\)/i;
 
 const AddIconUri = 'https://staticbrainz.org/MB/add-e585eab.png';
-// <option value="153">&nbsp;&nbsp;remixer</option>
-const RemixerOptionValue = '153';
-// <option value="230">&nbsp;&nbsp;remix of</option>
-const RemixOfOptionValue = '230';
 
 // This code is based on:
 // https://stackoverflow.com/questions/42795059/programmatically-fill-reactjs-form
@@ -70,7 +66,7 @@ function addStyleElement() {
 }
 
 function addRemixCreditLinks() {
-    const recordings = document.getElementsByClassName('recording');
+    const recordings = document.querySelectorAll('td.recording');
     const releaseArtists = Array.from(
         document
             .getElementsByClassName('subheader')[0]
@@ -93,7 +89,7 @@ function addRemixCreditLinks() {
         }
 
         let span = document.createElement('span');
-        if (linkTypes['remixer']) {
+        if (linkTypes['remixer:']) {
             span.className = 'add-rc btn disabled';
         } else {
             span.className = 'add-rc btn';
@@ -109,14 +105,15 @@ function addRemixCreditLinks() {
         recording.appendChild(document.createTextNode('\n'));
 
         span = document.createElement('span');
-        if (linkTypes['remix of']) {
+        if (linkTypes['remix of:']) {
             span.className = 'add-rc btn disabled';
         } else {
-            let trackArtists = Array.from(
-                recording
-                    .getElementsByTagName('span')[1]
-                    .getElementsByTagName('bdi')
-            ).map(bdi => bdi.innerText);
+            const trackArtistElement = recording
+                    .getElementsByTagName('span')[1];
+
+            let trackArtists = trackArtistElement ? Array.from(
+                trackArtistElement.getElementsByTagName('bdi')
+            ).map(bdi => bdi.innerText) : [];
             if (!trackArtists.length) {
                 trackArtists = releaseArtists;
             }
@@ -143,17 +140,20 @@ function addRemixCreditClickHandler(event) {
     const remixer = this.getAttribute('data-remixer');
     const remixOf = this.getAttribute('data-remix-of');
 
-    const addRel = recording.getElementsByClassName('add-rel')[0];
+    const addRel = recording.querySelector('button.add-relationship');
     addRel.click();
 
     if (remixer) {
         // wait 250ms for the dialog to be added to the DOM
         window.setTimeout(function () {
-            const dialog = document.getElementById('dialog');
-            const linkType = dialog.getElementsByClassName('link-type')[0];
-            setElementValue(linkType, RemixerOptionValue, 'change');
+            const dialog = document.getElementById('add-relationship-dialog');
+            const entityType = dialog.querySelector('select.entity-type');
+            setElementValue(entityType, 'artist', 'change');
 
-            const name = dialog.getElementsByClassName('name')[0];
+            const linkType = dialog.querySelector('input.relationship-type');
+            setElementValue(linkType, 'remixed / remixer');
+
+            const name = dialog.querySelector('input.relationship-target');
             if (remixer) {
                 setElementValue(name, remixer);
             } else {
@@ -163,16 +163,16 @@ function addRemixCreditClickHandler(event) {
     } else if (remixOf) {
         // wait 250ms for the dialog to be added to the DOM
         window.setTimeout(function () {
-            const dialog = document.getElementById('dialog');
-            const entityType = dialog.getElementsByClassName('entity-type')[0];
+            const dialog = document.getElementById('add-relationship-dialog');
+            const entityType = dialog.querySelector('select.entity-type');
             setElementValue(entityType, 'recording', 'change');
 
             // wait another 250ms for the link-type select options to be updated
             window.setTimeout(function () {
-                const linkType = dialog.getElementsByClassName('link-type')[0];
-                setElementValue(linkType, RemixOfOptionValue, 'change');
+                const linkType = dialog.querySelector('input.relationship-type');
+                setElementValue(linkType, 'remix of / has remixes');
 
-                const name = dialog.getElementsByClassName('name')[0];
+                const name = dialog.querySelector('input.relationship-target');
                 if (remixOf) {
                     setElementValue(name, remixOf);
                 } else {

--- a/mb_add_remix_credit_links.user.js
+++ b/mb_add_remix_credit_links.user.js
@@ -54,6 +54,17 @@ function setElementValue(element, value, event = 'input') {
     element.dispatchEvent(new Event(event, { bubbles: true }));
 }
 
+function tabToConfirmFirstOption(element) {
+    const event = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        keyCode: 9,
+        which: 9,
+        bubbles: true,
+        cancelable: true,
+    });
+    element.dispatchEvent(event);
+}
+
 function addRemixCreditLinks() {
     const recordings = document.querySelectorAll('td.recording');
     const releaseArtists = Array.from(
@@ -139,13 +150,13 @@ function addRemixCreditClickHandler(event) {
 
             const linkType = dialog.querySelector('input.relationship-type');
             setElementValue(linkType, 'remixed / remixer');
+            tabToConfirmFirstOption(linkType);
 
             const name = dialog.querySelector('input.relationship-target');
             if (remixer) {
                 setElementValue(name, remixer);
-            } else {
-                name.focus();
             }
+            name.focus();
         }, 250);
     } else if (remixOf) {
         // wait 250ms for the dialog to be added to the DOM
@@ -158,13 +169,13 @@ function addRemixCreditClickHandler(event) {
             window.setTimeout(function () {
                 const linkType = dialog.querySelector('input.relationship-type');
                 setElementValue(linkType, 'remix of / has remixes');
+                tabToConfirmFirstOption(linkType);
 
                 const name = dialog.querySelector('input.relationship-target');
                 if (remixOf) {
                     setElementValue(name, remixOf);
-                } else {
-                    name.focus();
                 }
+                name.focus();
             }, 250);
         }, 250);
     }

--- a/mb_add_remix_credit_links.user.js
+++ b/mb_add_remix_credit_links.user.js
@@ -153,10 +153,14 @@ function addRemixCreditClickHandler(event) {
             tabToConfirmFirstOption(linkType);
 
             const name = dialog.querySelector('input.relationship-target');
-            if (remixer) {
-                setElementValue(name, remixer);
+            setElementValue(name, remixer);
+            const search = name.parentElement.querySelector('button.search');
+            if (search) {
+                window.setTimeout(function() {
+                    search.click();
+                    name.focus();
+                }, 100);
             }
-            name.focus();
         }, 250);
     } else if (remixOf) {
         // wait 250ms for the dialog to be added to the DOM
@@ -172,10 +176,14 @@ function addRemixCreditClickHandler(event) {
                 tabToConfirmFirstOption(linkType);
 
                 const name = dialog.querySelector('input.relationship-target');
-                if (remixOf) {
-                    setElementValue(name, remixOf);
+                setElementValue(name, remixOf);
+                const search = name.parentElement.querySelector('button.search');
+                if (search) {
+                    window.setTimeout(function() {
+                        search.click();
+                        name.focus();
+                    }, 100);
                 }
-                name.focus();
             }, 250);
         }, 250);
     }


### PR DESCRIPTION
Fixes: https://github.com/atj/userscripts/issues/180

This might be a bit much for one PR. So, if you'd like, I can split it up into multiple PRs.

- The PR updates the selectors to use to find the relevant elements on the page.
- Updates the way the relationship type is filled in (seems it used to be `select` elements).
- Updates the look of the buttons a bit.
- Waits for the loading message to disappear before loading the main function.
- Updates the regex to also match `dub`. (New regex: https://regex101.com/r/0YdKH7/2, old regex: https://regex101.com/r/uXCxmJ/1). 
- Also, simplifies the regex a bit by moving in both _remix_ and _reedit_ into the main section, and moving out _rework_, since I assume only _re-work_ or _rework_ are allowed, but not just _work_.